### PR TITLE
 Release 0.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY commons /code/commons
 COPY specifications /code/specifications
 COPY restapi /code/restapi
 COPY java-sdk/gradle /code/java-sdk/gradle
-COPY java-sdk/gradle.properties java-sdk/build.gradle java-sdk/settings.gradle  java-sdk/gradlew /code/java-sdk/
+COPY java-sdk/build.gradle java-sdk/settings.gradle  java-sdk/gradlew /code/java-sdk/
 RUN ./gradlew tasks
 COPY java-sdk/radar-schemas-commons/build.gradle /code/java-sdk/radar-schemas-commons/
 COPY java-sdk/radar-schemas-commons/src /code/java-sdk/radar-schemas-commons/src

--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ docker-compose run --rm tools radar-schemas-tools register http://schema-registr
 # create topics with zookeeper
 docker-compose run --rm tools radar-schemas-tools create zookeeper-1:2181
 # run source-catalogue webservice
-docker-compose run --rm tools radar-schemas-tools catalogue-server (optional-port <portnumber>)
+docker-compose run --rm tools radar-schemas-tools serve -p <portnumber>
 
 ```

--- a/README.md
+++ b/README.md
@@ -58,4 +58,7 @@ docker-compose run --rm tools radar-schemas-tools list
 docker-compose run --rm tools radar-schemas-tools register http://schema-registry:8081
 # create topics with zookeeper
 docker-compose run --rm tools radar-schemas-tools create zookeeper-1:2181
+# run source-catalogue webservice
+docker-compose run --rm tools radar-schemas-tools catalogue-server (optional-port <portnumber>)
+
 ```

--- a/java-sdk/build.gradle
+++ b/java-sdk/build.gradle
@@ -17,7 +17,7 @@ subprojects {
     apply plugin: 'idea'
 
     // Configuration
-    version = '0.2.1-SNAPSHOT'
+    version = '0.2.1'
     group = 'org.radarcns'
     ext.githubRepoName = 'RADAR-CNS/RADAR-Schemas'
 

--- a/java-sdk/radar-schemas-tools/build.gradle
+++ b/java-sdk/radar-schemas-tools/build.gradle
@@ -36,8 +36,6 @@ dependencies {
     implementation group: 'org.eclipse.jetty', name: 'jetty-server', version: jettyVersion
     implementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version: jettyVersion
     implementation group: 'org.glassfish.jersey.core', name: 'jersey-server', version: jerseyVersion
-//    implementation group: 'org.glassfish.jersey.core', name: 'jersey-common', version: jerseyVersion
-//    implementation group: 'org.glassfish.jersey.core', name: 'jersey-client', version: jerseyVersion
     implementation group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet-core', version: jerseyVersion
     implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: jerseyVersion
 

--- a/java-sdk/radar-schemas-tools/build.gradle
+++ b/java-sdk/radar-schemas-tools/build.gradle
@@ -21,7 +21,8 @@ sourceSets {
 
 ext.junitVersion = '4.12'
 ext.slf4jVersion = '1.7.25'
-
+ext.jettyVersion = '9.4.7.v20170914'
+ext.jerseyVersion = '2.9'
 dependencies {
     api group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.10'
     api group: 'javax.validation', name: 'validation-api', version: '2.0.0.Final'
@@ -32,6 +33,13 @@ dependencies {
     implementation (group: 'org.apache.kafka', name: 'kafka_2.11', version: '0.11.0.1') {
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }
+    implementation group: 'org.eclipse.jetty', name: 'jetty-server', version: jettyVersion
+    implementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version: jettyVersion
+    implementation group: 'org.glassfish.jersey.core', name: 'jersey-server', version: jerseyVersion
+//    implementation group: 'org.glassfish.jersey.core', name: 'jersey-common', version: jerseyVersion
+//    implementation group: 'org.glassfish.jersey.core', name: 'jersey-client', version: jerseyVersion
+    implementation group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet-core', version: jerseyVersion
+    implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: jerseyVersion
 
     runtimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
 

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/CommandLineApp.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/CommandLineApp.java
@@ -24,6 +24,7 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparsers;
 import org.radarcns.schema.registration.KafkaTopics;
 import org.radarcns.schema.registration.SchemaRegistry;
+import org.radarcns.schema.service.SourceCatalogueServer;
 import org.radarcns.schema.specification.DataProducer;
 import org.radarcns.schema.specification.DataTopic;
 import org.radarcns.schema.specification.SourceCatalogue;
@@ -166,7 +167,8 @@ public class CommandLineApp {
                 KafkaTopics.command(),
                 SchemaRegistry.command(),
                 listCommand(),
-                SchemaValidator.command());
+                SchemaValidator.command(),
+                SourceCatalogueServer.command());
 
         ArgumentParser parser = getArgumentParser(subCommands);
 

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/CommandLineApp.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/CommandLineApp.java
@@ -54,6 +54,7 @@ import static java.util.stream.Collectors.toList;
  */
 @SuppressWarnings("PMD.SystemPrintln")
 public class CommandLineApp {
+
     private static final Logger logger = LoggerFactory.getLogger(CommandLineApp.class);
 
     private final SourceCatalogue catalogue;

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueServer.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueServer.java
@@ -77,7 +77,7 @@ public class SourceCatalogueServer implements Closeable {
         @Override
         public void addParser(ArgumentParser parser) {
             parser.description("Create all topics that are missing on the Kafka server.");
-            parser.addArgument("-p" ,"-port")
+            parser.addArgument("-p" ,"--port")
                     .help("Port number of the SourceCatalogue Server ")
                     .type(Integer.class)
                     .setDefault(9010);

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueServer.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueServer.java
@@ -76,7 +76,7 @@ public class SourceCatalogueServer implements Closeable {
 
         @Override
         public void addParser(ArgumentParser parser) {
-            parser.description("Create all topics that are missing on the Kafka server.");
+            parser.description("Port number of the Catalogue server.");
             parser.addArgument("-p" ,"--port")
                     .help("Port number of the SourceCatalogue Server ")
                     .type(Integer.class)

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueServer.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueServer.java
@@ -15,8 +15,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This server provides a webservice to share the SourceType Catalogues provided in *.yml files
- * as {@link org.radarcns.schema.service.SourceCatalogueService.SourceTypeResponse}
+ * This server provides a webservice to share the SourceType Catalogues provided in *.yml files as
+ * {@link org.radarcns.schema.service.SourceCatalogueService.SourceTypeResponse}
  */
 public class SourceCatalogueServer implements Closeable {
 

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueServer.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueServer.java
@@ -76,7 +76,7 @@ public class SourceCatalogueServer implements Closeable {
 
         @Override
         public void addParser(ArgumentParser parser) {
-            parser.description("Port number of the Catalogue server.");
+            parser.description("A web service to share source-type catalogs");
             parser.addArgument("-p" ,"--port")
                     .help("Port number of the SourceCatalogue Server ")
                     .type(Integer.class)

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueServer.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueServer.java
@@ -1,0 +1,88 @@
+package org.radarcns.schema.service;
+
+import java.io.Closeable;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.radarcns.schema.CommandLineApp;
+import org.radarcns.schema.specification.SourceCatalogue;
+import org.radarcns.schema.util.SubCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This server exposes the SourceType Catalogues provided as {@link SourceCatalogue} object
+ */
+public class SourceCatalogueServer implements Closeable {
+
+    private static final Logger logger = LoggerFactory.getLogger(SourceCatalogueServer.class);
+
+    private final Server server;
+
+    public SourceCatalogueServer(int serverPort) {
+        this.server = new Server(serverPort);
+    }
+
+    @Override
+    public void close() {
+        try {
+            this.server.join();
+        } catch (InterruptedException e) {
+            logger.error("Cannot stop server", e);
+        }
+        server.destroy();
+    }
+
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
+    private void start(SourceCatalogue sourceCatalogue) throws Exception {
+
+        ResourceConfig config = new ResourceConfig();
+        config.register(new SourceCatalogueService(sourceCatalogue));
+        ServletHolder servlet = new ServletHolder(new ServletContainer(config));
+        ServletContextHandler context = new ServletContextHandler(server, "/*");
+        context.addServlet(servlet, "/*");
+        server.start();
+    }
+
+    public static SubCommand command() {
+        return new SourceCatalogueServiceCommand();
+    }
+
+    private static class SourceCatalogueServiceCommand implements SubCommand {
+
+        @Override
+        public String getName() {
+            return "catalogue-server";
+        }
+
+        @Override
+        public int execute(Namespace options, CommandLineApp app) {
+            int partitions = options.getInt("port");
+            SourceCatalogueServer service = new SourceCatalogueServer(partitions);
+            try {
+                service.start(app.getCatalogue());
+            } catch (Exception e) {
+                logger.error("Cannot start server ", e);
+                return 1;
+            }
+            service.close();
+            return 0;
+        }
+
+        @Override
+        public void addParser(ArgumentParser parser) {
+            parser.description("Create all topics that are missing on the Kafka server.");
+            parser.addArgument("-port")
+                    .help("Port number of the SourceCatalogue Server ")
+                    .type(Integer.class)
+                    .setDefault(9010);
+            SubCommand.addRootArgument(parser); // is this always necessary?
+        }
+    }
+
+
+}

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueServer.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueServer.java
@@ -57,7 +57,7 @@ public class SourceCatalogueServer implements Closeable {
 
         @Override
         public String getName() {
-            return "catalogue-server";
+            return "serve";
         }
 
         @Override
@@ -77,7 +77,7 @@ public class SourceCatalogueServer implements Closeable {
         @Override
         public void addParser(ArgumentParser parser) {
             parser.description("Create all topics that are missing on the Kafka server.");
-            parser.addArgument("-port")
+            parser.addArgument("-p" ,"-port")
                     .help("Port number of the SourceCatalogue Server ")
                     .type(Integer.class)
                     .setDefault(9010);

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueServer.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueServer.java
@@ -15,7 +15,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This server exposes the SourceType Catalogues provided as {@link SourceCatalogue} object
+ * This server provides a webservice to share the SourceType Catalogues provided in *.yml files
+ * as {@link org.radarcns.schema.service.SourceCatalogueService.SourceTypeResponse}
  */
 public class SourceCatalogueServer implements Closeable {
 
@@ -80,7 +81,7 @@ public class SourceCatalogueServer implements Closeable {
                     .help("Port number of the SourceCatalogue Server ")
                     .type(Integer.class)
                     .setDefault(9010);
-            SubCommand.addRootArgument(parser); // is this always necessary?
+            SubCommand.addRootArgument(parser);
         }
     }
 

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueService.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueService.java
@@ -1,0 +1,29 @@
+package org.radarcns.schema.service;
+
+import org.radarcns.schema.specification.SourceCatalogue;
+import org.radarcns.schema.specification.passive.PassiveSource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.ArrayList;
+import java.util.List;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+public class SourceCatalogueService {
+
+    private final SourceCatalogue sourceCatalogue;
+
+    public SourceCatalogueService(SourceCatalogue sourceCatalogue) {
+        this.sourceCatalogue = sourceCatalogue;
+    }
+
+    @GET
+    @Path("passive-sources")
+    public List<PassiveSource> getPassiveSources() {
+        List<PassiveSource> result = new ArrayList<>(this.sourceCatalogue.getPassiveSources().values());
+        return  result;
+    }
+}

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueService.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueService.java
@@ -16,8 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Webservice resource to share SourceCatalogues. The response has a "Source-Type-Class" header
- * that mentions the class of SourceCatalogues and the body has the SourceCatalogues in JSON format.
+ * Webservice resource to share SourceCatalogues. The response has a "Source-Type-Class" header that
+ * mentions the class of SourceCatalogues and the body has the SourceCatalogues in JSON format.
  */
 @Path("/source-types")
 @Produces(MediaType.APPLICATION_JSON)
@@ -47,24 +47,20 @@ public class SourceCatalogueService {
     @GET
     @Path("/monitor")
     public Response getMonitorSources() {
-        return  Response.ok().entity(new SourceTypeResponse(this.sourceCatalogue).monitor())
+        return Response.ok().entity(new SourceTypeResponse(this.sourceCatalogue).monitor())
                 .header(SOURCE_TYPE_CLASS_HEADER, "MONITOR").build();
     }
 
     @GET
     public Response getAllSourceTypes() {
-        return  Response.ok().entity(new SourceTypeResponse(this.sourceCatalogue).all())
+        return Response.ok().entity(new SourceTypeResponse(this.sourceCatalogue).all())
                 .header(SOURCE_TYPE_CLASS_HEADER, "ALL").build();
     }
 
     public class SourceTypeResponse {
 
         @JsonIgnore
-        private SourceCatalogue sourceCatalogue;
-
-        private SourceTypeResponse(SourceCatalogue sourceCatalogue) {
-            this.sourceCatalogue = sourceCatalogue;
-        }
+        private final SourceCatalogue sourceCatalogue;
 
         @JsonProperty("passive-source-types")
         private List<PassiveSource> passiveSources;
@@ -74,6 +70,10 @@ public class SourceCatalogueService {
 
         @JsonProperty("monitor-source-types")
         private List<MonitorSource> monitorSources;
+
+        private SourceTypeResponse(SourceCatalogue sourceCatalogue) {
+            this.sourceCatalogue = sourceCatalogue;
+        }
 
         private SourceTypeResponse passive() {
             this.passiveSources = new ArrayList<>(
@@ -87,7 +87,8 @@ public class SourceCatalogueService {
         }
 
         public SourceTypeResponse monitor() {
-            this.monitorSources = new ArrayList<>(this.sourceCatalogue.getMonitorSources().values());
+            this.monitorSources = new ArrayList<>(
+                    this.sourceCatalogue.getMonitorSources().values());
             return this;
         }
 
@@ -95,7 +96,8 @@ public class SourceCatalogueService {
             this.passiveSources = new ArrayList<>(
                     this.sourceCatalogue.getPassiveSources().values());
             this.activeSources = new ArrayList<>(this.sourceCatalogue.getActiveSources().values());
-            this.monitorSources = new ArrayList<>(this.sourceCatalogue.getMonitorSources().values());
+            this.monitorSources = new ArrayList<>(
+                    this.sourceCatalogue.getMonitorSources().values());
             return this;
         }
 

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueService.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/service/SourceCatalogueService.java
@@ -1,29 +1,114 @@
 package org.radarcns.schema.service;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.radarcns.schema.specification.SourceCatalogue;
+import org.radarcns.schema.specification.active.ActiveSource;
+import org.radarcns.schema.specification.monitor.MonitorSource;
 import org.radarcns.schema.specification.passive.PassiveSource;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 
-@Path("/")
+/**
+ * Webservice resource to share SourceCatalogues. The response has a "Source-Type-Class" header
+ * that mentions the class of SourceCatalogues and the body has the SourceCatalogues in JSON format.
+ */
+@Path("/source-types")
 @Produces(MediaType.APPLICATION_JSON)
 public class SourceCatalogueService {
 
+    private static final String SOURCE_TYPE_CLASS_HEADER = "Source-Type-Class";
     private final SourceCatalogue sourceCatalogue;
 
-    public SourceCatalogueService(SourceCatalogue sourceCatalogue) {
+    SourceCatalogueService(SourceCatalogue sourceCatalogue) {
         this.sourceCatalogue = sourceCatalogue;
     }
 
     @GET
-    @Path("passive-sources")
-    public List<PassiveSource> getPassiveSources() {
-        List<PassiveSource> result = new ArrayList<>(this.sourceCatalogue.getPassiveSources().values());
-        return  result;
+    @Path("/passive")
+    public Response getPassiveSources() {
+        return Response.ok().entity(new SourceTypeResponse(this.sourceCatalogue).passive())
+                .header(SOURCE_TYPE_CLASS_HEADER, "PASSIVE").build();
+    }
+
+    @GET
+    @Path("/active")
+    public Response getActiveSources() {
+        return Response.ok().entity(new SourceTypeResponse(this.sourceCatalogue).active())
+                .header(SOURCE_TYPE_CLASS_HEADER, "ACTIVE").build();
+    }
+
+    @GET
+    @Path("/monitor")
+    public Response getMonitorSources() {
+        return  Response.ok().entity(new SourceTypeResponse(this.sourceCatalogue).monitor())
+                .header(SOURCE_TYPE_CLASS_HEADER, "MONITOR").build();
+    }
+
+    @GET
+    public Response getAllSourceTypes() {
+        return  Response.ok().entity(new SourceTypeResponse(this.sourceCatalogue).all())
+                .header(SOURCE_TYPE_CLASS_HEADER, "ALL").build();
+    }
+
+    public class SourceTypeResponse {
+
+        @JsonIgnore
+        private SourceCatalogue sourceCatalogue;
+
+        private SourceTypeResponse(SourceCatalogue sourceCatalogue) {
+            this.sourceCatalogue = sourceCatalogue;
+        }
+
+        @JsonProperty("passive-source-types")
+        private List<PassiveSource> passiveSources;
+
+        @JsonProperty("active-source-types")
+        private List<ActiveSource> activeSources;
+
+        @JsonProperty("monitor-source-types")
+        private List<MonitorSource> monitorSources;
+
+        private SourceTypeResponse passive() {
+            this.passiveSources = new ArrayList<>(
+                    this.sourceCatalogue.getPassiveSources().values());
+            return this;
+        }
+
+        public SourceTypeResponse active() {
+            this.activeSources = new ArrayList<>(this.sourceCatalogue.getActiveSources().values());
+            return this;
+        }
+
+        public SourceTypeResponse monitor() {
+            this.monitorSources = new ArrayList<>(this.sourceCatalogue.getMonitorSources().values());
+            return this;
+        }
+
+        private SourceTypeResponse all() {
+            this.passiveSources = new ArrayList<>(
+                    this.sourceCatalogue.getPassiveSources().values());
+            this.activeSources = new ArrayList<>(this.sourceCatalogue.getActiveSources().values());
+            this.monitorSources = new ArrayList<>(this.sourceCatalogue.getMonitorSources().values());
+            return this;
+        }
+
+        public List<PassiveSource> getPassiveSources() {
+            return passiveSources;
+        }
+
+        public List<ActiveSource> getActiveSources() {
+            return activeSources;
+        }
+
+        public List<MonitorSource> getMonitorSources() {
+            return monitorSources;
+        }
     }
 }

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/specification/AppSource.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/specification/AppSource.java
@@ -3,8 +3,6 @@ package org.radarcns.schema.specification;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import java.util.Objects;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 import static org.radarcns.schema.util.Utils.expandClass;
 

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/specification/AppSource.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/specification/AppSource.java
@@ -2,12 +2,24 @@ package org.radarcns.schema.specification;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import java.util.Objects;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 import static org.radarcns.schema.util.Utils.expandClass;
 
 public abstract class AppSource<T extends DataTopic> extends DataProducer<T> {
     @JsonProperty("app_provider")
     private String appProvider;
+
+    @JsonProperty
+    private String vendor;
+
+    @JsonProperty
+    private String model;
+
+    @JsonProperty
+    private String version;
 
     @JsonSetter
     @SuppressWarnings("PMD.UnusedPrivateMethod")
@@ -17,5 +29,38 @@ public abstract class AppSource<T extends DataTopic> extends DataProducer<T> {
 
     public String getAppProvider() {
         return appProvider;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getVendor() {
+        return vendor;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AppSource provider = (AppSource) o;
+        return Objects.equals(appProvider, provider.appProvider)
+                && Objects.equals(version, provider.version)
+                && Objects.equals(model, provider.model)
+                && Objects.equals(vendor, provider.vendor)
+                && Objects.equals(getData(), provider.getData());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(appProvider, vendor, model, version, getData());
     }
 }

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/specification/DataProducer.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/specification/DataProducer.java
@@ -26,19 +26,12 @@ public abstract class DataProducer<T extends DataTopic> {
     @JsonProperty
     private List<String> labels;
 
-    @JsonProperty
-    private String version;
-
     public String getName() {
         return name;
     }
 
     public String getDoc() {
         return doc;
-    }
-
-    public String getVersion() {
-        return version;
     }
 
     @NotNull
@@ -75,12 +68,11 @@ public abstract class DataProducer<T extends DataTopic> {
         DataProducer producer = (DataProducer) o;
         return Objects.equals(name, producer.name)
                 && Objects.equals(doc, producer.doc)
-                && Objects.equals(version , producer.version)
                 && Objects.equals(getData(), producer.getData());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, doc, getData(), version);
+        return Objects.hash(name, doc, getData());
     }
 }

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/specification/DataProducer.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/specification/DataProducer.java
@@ -26,12 +26,19 @@ public abstract class DataProducer<T extends DataTopic> {
     @JsonProperty
     private List<String> labels;
 
+    @JsonProperty
+    private String version;
+
     public String getName() {
         return name;
     }
 
     public String getDoc() {
         return doc;
+    }
+
+    public String getVersion() {
+        return version;
     }
 
     @NotNull
@@ -56,6 +63,7 @@ public abstract class DataProducer<T extends DataTopic> {
         return getData().stream().flatMap(applyOrEmpty(DataTopic::getTopics));
     }
 
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -67,11 +75,12 @@ public abstract class DataProducer<T extends DataTopic> {
         DataProducer producer = (DataProducer) o;
         return Objects.equals(name, producer.name)
                 && Objects.equals(doc, producer.doc)
+                && Objects.equals(version , producer.version)
                 && Objects.equals(getData(), producer.getData());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, doc, getData());
+        return Objects.hash(name, doc, getData(), version);
     }
 }

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/specification/active/ActiveSource.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/specification/active/ActiveSource.java
@@ -47,6 +47,15 @@ public class ActiveSource<T extends DataTopic> extends DataProducer<T> {
     @JsonProperty
     private List<T> data;
 
+    @JsonProperty
+    private String vendor;
+
+    @JsonProperty
+    private String model;
+
+    @JsonProperty
+    private String version;
+
     public String getAssessmentType() {
         return assessmentType;
     }
@@ -59,5 +68,17 @@ public class ActiveSource<T extends DataTopic> extends DataProducer<T> {
     @Override
     public Scope getScope() {
         return Scope.ACTIVE;
+    }
+
+    public String getVendor() {
+        return vendor;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public String getVersion() {
+        return version;
     }
 }

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/specification/passive/PassiveSource.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/specification/passive/PassiveSource.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.radarcns.schema.Scope;
 import org.radarcns.schema.specification.AppSource;
 
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.util.List;
@@ -48,14 +47,6 @@ public class PassiveSource extends AppSource<PassiveDataTopic> {
 
     public String getName() {
         return super.getVendor() + '_' + super.getModel();
-    }
-
-    public String getVendor() {
-        return super.getVendor();
-    }
-
-    public String getModel() {
-        return super.getModel();
     }
 
     /**

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/specification/passive/PassiveSource.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/specification/passive/PassiveSource.java
@@ -33,12 +33,6 @@ public class PassiveSource extends AppSource<PassiveDataTopic> {
         EMPATICA_E4, PEBBLE_2, ANDROID_PHONE, BIOVOTION_VSM1
     }
 
-    @JsonProperty @NotBlank
-    private String vendor;
-
-    @JsonProperty @NotBlank
-    private String model;
-
     @JsonProperty @NotEmpty
     private List<PassiveDataTopic> data;
 
@@ -53,15 +47,15 @@ public class PassiveSource extends AppSource<PassiveDataTopic> {
     }
 
     public String getName() {
-        return vendor + '_' + model;
+        return super.getVendor() + '_' + super.getModel();
     }
 
     public String getVendor() {
-        return vendor;
+        return super.getVendor();
     }
 
     public String getModel() {
-        return model;
+        return super.getModel();
     }
 
     /**

--- a/specifications/active/phq8.yml
+++ b/specifications/active/phq8.yml
@@ -2,7 +2,7 @@
 name: PHQ8
 vendor: PHQ
 model: 8
-version: v1
+version: 1.0.0
 assessment_type: QUESTIONNAIRE
 doc: Personal Health Questionnaire Depression Scale (PHQ-8) definition.
 data:

--- a/specifications/active/phq8.yml
+++ b/specifications/active/phq8.yml
@@ -1,5 +1,8 @@
 #==================== Personal Health Questionnaire Depression Scale (PHQ-8) ======================#
 name: PHQ8
+vendor: PHQ
+model: 8
+version: v1
 assessment_type: QUESTIONNAIRE
 doc: Personal Health Questionnaire Depression Scale (PHQ-8) definition.
 data:

--- a/specifications/active/thincit.yml
+++ b/specifications/active/thincit.yml
@@ -1,7 +1,7 @@
 name: THINCIT
-vendor: LUNDBECK
+vendor: THINCIT IIRC
 model: THINCIT
-version: v1
+version: 1.0.0
 assessment_type: APP
 doc: ThincIt Cognition in Depression app.
 data:

--- a/specifications/active/thincit.yml
+++ b/specifications/active/thincit.yml
@@ -1,4 +1,7 @@
 name: THINCIT
+vendor: LUNDBECK
+model: THINCIT
+version: v1
 assessment_type: APP
 doc: ThincIt Cognition in Depression app.
 data:

--- a/specifications/monitor/radar_prmt.yml
+++ b/specifications/monitor/radar_prmt.yml
@@ -1,7 +1,7 @@
 name: ANDROID_PHONE
 vendor: ANDROID
 model: PHONE_MONITOR
-version: v1
+version: 1.0.0
 doc: Status updates from the RADAR-CNS pRMT app.
 app_provider: .application.ApplicationServiceProvider
 data:

--- a/specifications/monitor/radar_prmt.yml
+++ b/specifications/monitor/radar_prmt.yml
@@ -1,4 +1,7 @@
 name: ANDROID_PHONE
+vendor: ANDROID
+model: PHONE_MONITOR
+version: v1
 doc: Status updates from the RADAR-CNS pRMT app.
 app_provider: .application.ApplicationServiceProvider
 data:

--- a/specifications/passive/android_phone.yml
+++ b/specifications/passive/android_phone.yml
@@ -1,6 +1,7 @@
 #====================================== Android Phone Sensors =====================================#
 vendor: ANDROID
 model: PHONE
+version: v1
 data:
   #Phone sensors
   - type: ACCELEROMETER

--- a/specifications/passive/android_phone.yml
+++ b/specifications/passive/android_phone.yml
@@ -1,7 +1,7 @@
 #====================================== Android Phone Sensors =====================================#
 vendor: ANDROID
 model: PHONE
-version: v1
+version: 1.0.0
 data:
   #Phone sensors
   - type: ACCELEROMETER

--- a/specifications/passive/biovotion_vsm1.yml
+++ b/specifications/passive/biovotion_vsm1.yml
@@ -1,7 +1,7 @@
 #===================================== Biovotion VSM1 Everion =====================================#
 vendor: BIOVOTION
 model: VSM1
-version: v1
+version: 1.0.0
 app_provider: .biovotion.BiovotionServiceProvider
 data:
   - type: ACCELEROMETER

--- a/specifications/passive/biovotion_vsm1.yml
+++ b/specifications/passive/biovotion_vsm1.yml
@@ -1,6 +1,7 @@
 #===================================== Biovotion VSM1 Everion =====================================#
 vendor: BIOVOTION
 model: VSM1
+version: v1
 app_provider: .biovotion.BiovotionServiceProvider
 data:
   - type: ACCELEROMETER

--- a/specifications/passive/empatica_e4.yml
+++ b/specifications/passive/empatica_e4.yml
@@ -1,6 +1,7 @@
 #====================================== Empatica E4 Wristband =====================================#
 vendor: EMPATICA
 model: E4
+version: v1
 app_provider: .empatica.E4ServiceProvider
 data:
   - type: ACCELEROMETER

--- a/specifications/passive/empatica_e4.yml
+++ b/specifications/passive/empatica_e4.yml
@@ -1,7 +1,7 @@
 #====================================== Empatica E4 Wristband =====================================#
 vendor: EMPATICA
 model: E4
-version: v1
+version: 1.0.0
 app_provider: .empatica.E4ServiceProvider
 data:
   - type: ACCELEROMETER

--- a/specifications/passive/pebble_2.yml
+++ b/specifications/passive/pebble_2.yml
@@ -1,6 +1,7 @@
 #============================================ Pebble 2 ============================================#
 vendor: PEBBLE
 model: 2
+version: v1
 doc: Pebble 2 data collected over Bluetooth by a RADAR Pebble app
 app_provider: .pebble.PebbleServiceProvider
 data:

--- a/specifications/passive/pebble_2.yml
+++ b/specifications/passive/pebble_2.yml
@@ -1,7 +1,7 @@
 #============================================ Pebble 2 ============================================#
 vendor: PEBBLE
 model: 2
-version: v1
+version: 1.0.0
 doc: Pebble 2 data collected over Bluetooth by a RADAR Pebble app
 app_provider: .pebble.PebbleServiceProvider
 data:


### PR DESCRIPTION
Introduces catalog server to share source-type specifications provided here. This introduces new properties to uniquely identify a specification version by the combination of vendor, model, version. These three properties are required to create a source-type on ManagementPortal of RADAR.

The catalog server can be run from radar-schema-tools with serve -p <port>