### PR TITLE
Harmonize aggregate key

### DIFF
--- a/commons/kafka/aggregate_key.avsc
+++ b/commons/kafka/aggregate_key.avsc
@@ -7,7 +7,7 @@
     {"name": "projectId", "type": ["null", "string"], "doc": "Project that the key belongs to.", "default": null},
     {"name": "userId", "type": "string", "doc": "User Identifier created during the enrolment."},
     {"name": "sourceId", "type": "string", "doc": "Unique identifier associated with the source."},
-    {"name": "start", "type": "long", "doc": "First timestamp in UNIX time contained in the time window."},
-    {"name": "end", "type": "long", "doc": "Last timestamp in UNIX time contained in the time window."}
+    {"name": "timeStart", "type": "double", "doc": "Time (seconds since the UNIX Epoch) of the time window start."},
+    {"name": "timeEnd", "type": "double", "doc": "Time (seconds since the UNIX Epoch) of the time window end."}
   ]
 }

--- a/java-sdk/radar-schemas-tools/build.gradle
+++ b/java-sdk/radar-schemas-tools/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'application'
 }
 
+apply plugin: 'com.jfrog.artifactory'
+
 ext.artifactName = 'radar-schemas-tools'
 ext.description = 'RADAR Schemas specification and validation tools.'
 
@@ -139,4 +141,20 @@ bintray {
             released = new Date()
         }
     }
+}
+
+artifactory {
+    contextUrl = 'https://oss.jfrog.org/artifactory'
+    publish {
+        repository {
+            repoKey = 'oss-snapshot-local'
+            username = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+            password = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
+            maven = true
+        }
+    }
+}
+
+artifactoryPublish {
+    publications('RadarCommonsPublication')
 }


### PR DESCRIPTION
Use the same JSON guidelines for `time` fields in the aggregate keys as in other objects. This makes a standard MongoDB implementation simpler, as well as the backend code and handling.